### PR TITLE
feat: contract method for getting deposit list

### DIFF
--- a/contracts/src/interfaces/ipeer_protocol.cairo
+++ b/contracts/src/interfaces/ipeer_protocol.cairo
@@ -1,8 +1,10 @@
 use starknet::ContractAddress;
+use peer_protocol::peer_protocol::PeerProtocol::UserDeposit;
 
 #[starknet::interface]
 pub trait IPeerProtocol<TContractState> {
     fn deposit(ref self: TContractState, token_address: ContractAddress, amount: u256);
     fn add_supported_token(ref self: TContractState, token_address: ContractAddress);
     fn withdraw(ref self: TContractState, token_address: ContractAddress, amount: u256);
+    fn get_user_deposits(self: @TContractState, user: ContractAddress) -> Span<UserDeposit>;
 }

--- a/contracts/src/mocks/mock_token.cairo
+++ b/contracts/src/mocks/mock_token.cairo
@@ -43,8 +43,8 @@ pub mod MockToken {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState) {
-        self.token_name.write("Mock Token");
+    fn constructor(ref self: ContractState, name: ByteArray) {
+        self.token_name.write(name);
         self.symbol.write("MKT");
         self.decimal.write(18);
         self.owner.write(get_caller_address());

--- a/contracts/src/peer_protocol.cairo
+++ b/contracts/src/peer_protocol.cairo
@@ -161,7 +161,18 @@ mod PeerProtocol {
             user_assets
         }
 
+        /// Returns all active deposits for a given user across supported tokens
+        /// @param user The address of the user whose deposits to retrieve
+        /// @return A Span of UserDeposit structs containing only tokens with non-zero balances
+        ///
+        /// The method:
+        /// - Filters out tokens with zero balances
+        /// - Returns empty span if user has no deposits
+        /// - Includes token address and amount for each active deposit
+
         fn get_user_deposits(self: @ContractState, user: ContractAddress) -> Span<UserDeposit> {
+            assert!(user != contract_address_const::<0>(), "invalid user address");
+
             let mut user_deposits = array![];
             for i in 0..self.supported_token_list.len() {
                 let token = self.supported_token_list.at(i).read();

--- a/contracts/src/peer_protocol.cairo
+++ b/contracts/src/peer_protocol.cairo
@@ -84,6 +84,7 @@ mod PeerProtocol {
             assert!(self.supported_tokens.entry(token_address).read() == false, "token already added");
 
             self.supported_tokens.entry(token_address).write(true);
+            self.supported_tokens_list.append().write(token_address);
 
             self.emit(SupportedTokenAdded { token: token_address });
         }
@@ -115,7 +116,9 @@ mod PeerProtocol {
             for i in 0..self.supported_tokens_list.len() {
                 let token = self.supported_tokens_list.at(i).read();
                 let deposit = self.token_deposits.entry((user, token)).read();
-                user_deposits.append(UserDeposit { token: token, amount: deposit });
+                if deposit > 0 {
+                    user_deposits.append(UserDeposit { token: token, amount: deposit });
+                }
             };
             user_deposits.span()
         }

--- a/contracts/tests/test_peer_protocol.cairo
+++ b/contracts/tests/test_peer_protocol.cairo
@@ -226,4 +226,9 @@ fn test_get_user_deposits() {
     assert!(deposit1.token != deposit2.token, "duplicate tokens in result");
 
     stop_cheat_caller_address(peer_protocol_address);
+
+    // Test for random user
+    let random_user: ContractAddress = starknet::contract_address_const::<0x987654321>();
+    let random_user_deposits = peer_protocol.get_user_deposits(random_user);
+    assert!(random_user_deposits.len() == 0, "random user should have no deposits");
 }

--- a/contracts/tests/test_peer_protocol.cairo
+++ b/contracts/tests/test_peer_protocol.cairo
@@ -14,9 +14,12 @@ use peer_protocol::interfaces::ierc20::{IERC20Dispatcher, IERC20DispatcherTrait}
 const ONE_E18: u256 = 1000000000000000000_u256;
 
 fn deploy_token(name: ByteArray) -> ContractAddress {
-    let contract = declare(name).unwrap().contract_class();
+    let contract = declare("MockToken").unwrap().contract_class();
 
-    let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+    let mut constructor_calldata = ArrayTrait::new();
+    name.serialize(ref constructor_calldata);
+
+    let (contract_address, _) = contract.deploy(@constructor_calldata).unwrap();
 
     contract_address
 }
@@ -151,6 +154,78 @@ fn test_withdraw() {
         }
     );
     spy.assert_emitted(@array![(peer_protocol_address, expected_event)]);
+
+    stop_cheat_caller_address(peer_protocol_address);
+}
+
+#[test]
+fn test_get_user_deposits() {
+    // Deploy contracts
+    let token1_address = deploy_token("MockToken1");
+    let token2_address = deploy_token("MockToken2");
+    // add another supported token without balance
+    let token3_address = deploy_token("MockToken3");
+    let peer_protocol_address = deploy_peer_protocol();
+
+    // Setup dispatchers
+    let token1 = IERC20Dispatcher { contract_address: token1_address };
+    let token2 = IERC20Dispatcher { contract_address: token2_address };
+    let peer_protocol = IPeerProtocolDispatcher { contract_address: peer_protocol_address };
+
+    // Setup addresses
+    let owner: ContractAddress = starknet::contract_address_const::<0x123626789>();
+    let user: ContractAddress = starknet::contract_address_const::<0x122226789>();
+
+    // Define amounts
+    let mint_amount: u256 = 1000 * ONE_E18;
+    let deposit_amount1: u256 = 100 * ONE_E18;
+    let deposit_amount2: u256 = 200 * ONE_E18;
+
+    // Add supported tokens
+    start_cheat_caller_address(peer_protocol_address, owner);
+    peer_protocol.add_supported_token(token1_address);
+    peer_protocol.add_supported_token(token2_address);
+    peer_protocol.add_supported_token(token3_address);
+    stop_cheat_caller_address(peer_protocol_address);
+
+    // Mint tokens to user
+    token1.mint(user, mint_amount);
+    token2.mint(user, mint_amount);
+
+    // Approve spending
+    start_cheat_caller_address(token1_address, user);
+    token1.approve(peer_protocol_address, mint_amount);
+    stop_cheat_caller_address(token1_address);
+
+    start_cheat_caller_address(token2_address, user);
+    token2.approve(peer_protocol_address, mint_amount);
+    stop_cheat_caller_address(token2_address);
+
+    // Make deposits
+    start_cheat_caller_address(peer_protocol_address, user);
+    peer_protocol.deposit(token1_address, deposit_amount1);
+    peer_protocol.deposit(token2_address, deposit_amount2);
+
+    // Get and verify user deposits
+    let user_deposits = peer_protocol.get_user_deposits(user);
+
+    assert!(user_deposits.len() == 2, "incorrect number of deposits");
+
+    // Verify deposit amounts for each token
+    let deposit1 = user_deposits.at(0);
+    let deposit2 = user_deposits.at(1);
+
+    assert!(
+        (*deposit1.token == token1_address && *deposit1.amount == deposit_amount1)
+            || (*deposit1.token == token2_address && *deposit1.amount == deposit_amount2),
+        "incorrect deposit1"
+    );
+    assert!(
+        (*deposit2.token == token1_address && *deposit2.amount == deposit_amount1)
+            || (*deposit2.token == token2_address && *deposit2.amount == deposit_amount2),
+        "incorrect deposit2"
+    );
+    assert!(deposit1.token != deposit2.token, "duplicate tokens in result");
 
     stop_cheat_caller_address(peer_protocol_address);
 }

--- a/contracts/tests/test_peer_protocol.cairo
+++ b/contracts/tests/test_peer_protocol.cairo
@@ -285,3 +285,15 @@ fn test_get_user_deposits() {
     let random_user_deposits = peer_protocol.get_user_deposits(random_user);
     assert!(random_user_deposits.len() == 0, "random user should have no deposits");
 }
+
+#[test]
+#[should_panic(expected: "invalid user address")]
+fn test_get_user_deposits_with_zero_address() {
+    // Deploy contracts
+    let peer_protocol_address = deploy_peer_protocol();
+    let peer_protocol = IPeerProtocolDispatcher { contract_address: peer_protocol_address };
+
+    // Test with zero address - should panic
+    let zero_address: ContractAddress = starknet::contract_address_const::<0>();
+    peer_protocol.get_user_deposits(zero_address);
+}

--- a/contracts/tests/test_peer_protocol.cairo
+++ b/contracts/tests/test_peer_protocol.cairo
@@ -216,13 +216,11 @@ fn test_get_user_deposits() {
     let deposit2 = user_deposits.at(1);
 
     assert!(
-        (*deposit1.token == token1_address && *deposit1.amount == deposit_amount1)
-            || (*deposit1.token == token2_address && *deposit1.amount == deposit_amount2),
+        *deposit1.token == token1_address && *deposit1.amount == deposit_amount1,
         "incorrect deposit1"
     );
     assert!(
-        (*deposit2.token == token1_address && *deposit2.amount == deposit_amount1)
-            || (*deposit2.token == token2_address && *deposit2.amount == deposit_amount2),
+        *deposit2.token == token2_address && *deposit2.amount == deposit_amount2,
         "incorrect deposit2"
     );
     assert!(deposit1.token != deposit2.token, "duplicate tokens in result");


### PR DESCRIPTION
PR resume:
- Added new storage variable: `supported_tokens_list` for enumerating all supported tokens
- Added new function `get_user_deposits` that returns the list of all non-zero deposits belonging to the given user
- Changed Mock token constructor to receive `name` as an argument (to be able to differentiate between several deployed tokens potentially)
- Added test for the common case (contains some zero and non-zero balances)

The idea is the same as in #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a method to retrieve user deposit information.
	- Added support for dynamic token naming in the mock token contract.
  
- **Bug Fixes**
	- Enhanced the management of supported tokens in the peer protocol.

- **Tests**
	- Added new tests to verify the functionality of retrieving user deposits and error handling for invalid user addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->